### PR TITLE
2.4.12 release

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -74,6 +74,7 @@ class ConfigProvider implements ConfigProviderInterface
                     'apiLoginID' => $this->config->getApiLoginId($storeId),
                     'sdkUrl' => $this->config->getSdkUrl($storeId),
                     'vaultCode' => self::VAULT_CODE,
+                    'isCimEnabled' => $this->config->isCIMEnabled($storeId)
                 ],
                 'verify_authorize' => [
                     'enabled' => (int)$this->config->isVerify3DSecure($storeId),

--- a/Plugin/Framework/App/Config/AfterGetTnwAuthorizeCimVaultActiveValue.php
+++ b/Plugin/Framework/App/Config/AfterGetTnwAuthorizeCimVaultActiveValue.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © TechNWeb, Inc. All rights reserved.
+ * See TNW_LICENSE.txt for license details.
+ */
+
+namespace TNW\AuthorizeCim\Plugin\Framework\App\Config;
+
+use Magento\Vault\Model\CustomerTokenManagement\Proxy as CustomerTokenManagement;
+
+/**
+ * Plugin for enabling Authorize.net vault payments if vault is disabled, but customer has saved cards
+ */
+class AfterGetTnwAuthorizeCimVaultActiveValue
+{
+    /**
+     * @var CustomerTokenManagement
+     */
+    private $customerTokenManagement;
+
+    /**
+     * @var bool|null
+     */
+    private $customerHasTokens;
+
+    /**
+     * AfterGetTnwAuthorizeCimVaultActiveValue constructor
+     *
+     * @param CustomerTokenManagement $customerTokenManagement
+     */
+    public function __construct(CustomerTokenManagement $customerTokenManagement)
+    {
+        $this->customerTokenManagement = $customerTokenManagement;
+    }
+
+    /**
+     * Overrides 'active' config value of Auth.net CIM vault payment method when customer have active payment tokens.
+     *
+     * @param \Magento\Framework\App\Config $subject
+     * @param mixed $result
+     * @param string|null $path
+     * @return bool|mixed|null
+     */
+    public function afterGetValue(\Magento\Framework\App\Config $subject, $result, $path = null)
+    {
+        if ($path === 'payment/tnw_authorize_cim_vault/active' && !$result) {
+            return $this->getCustomerHasTokens();
+        }
+        return $result;
+    }
+
+    /**
+     * Checks if customer has Authorize.net CIM tokens
+     *
+     * @return bool
+     */
+    private function getCustomerHasTokens()
+    {
+        if ($this->customerHasTokens === null) {
+            $tokens = $this->customerTokenManagement->getCustomerSessionTokens();
+            $this->customerHasTokens = false;
+            foreach ($tokens as $token) {
+                if ($token->getPaymentMethodCode() === 'tnw_authorize_cim') {
+                    $this->customerHasTokens = true;
+                    break;
+                }
+            }
+        }
+
+        return $this->customerHasTokens;
+    }
+}

--- a/Plugin/Framework/App/Config/AfterGetTnwAuthorizeCimVaultActiveValue.php
+++ b/Plugin/Framework/App/Config/AfterGetTnwAuthorizeCimVaultActiveValue.php
@@ -6,6 +6,7 @@
 
 namespace TNW\AuthorizeCim\Plugin\Framework\App\Config;
 
+use Magento\Framework\App\Config;
 use Magento\Vault\Model\CustomerTokenManagement\Proxy as CustomerTokenManagement;
 
 /**
@@ -36,12 +37,12 @@ class AfterGetTnwAuthorizeCimVaultActiveValue
     /**
      * Overrides 'active' config value of Auth.net CIM vault payment method when customer have active payment tokens.
      *
-     * @param \Magento\Framework\App\Config $subject
+     * @param Config $subject
      * @param mixed $result
      * @param string|null $path
      * @return bool|mixed|null
      */
-    public function afterGetValue(\Magento\Framework\App\Config $subject, $result, $path = null)
+    public function afterGetValue(Config $subject, $result, $path = null)
     {
         if ($path === 'payment/tnw_authorize_cim_vault/active' && !$result) {
             return $this->getCustomerHasTokens();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnw/module-authorizenetcim",
   "description": "Authorize.net CIM for Magento 2",
   "type": "magento2-module",
-  "version": "2.4.10",
+  "version": "2.4.12",
   "license": [
     "proprietary"
   ],

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -34,4 +34,10 @@
       </argument>
     </arguments>
   </type>
+    <type name="Magento\Framework\App\Config">
+        <plugin
+            name="after_get_tnw_authorize_cim_vault_active_value"
+            type="TNW\AuthorizeCim\Plugin\Framework\App\Config\AfterGetTnwAuthorizeCimVaultActiveValue"
+        />
+    </type>
 </config>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © TechNWeb, Inc. All rights reserved.
+ * See TNW_LICENSE.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\App\Config">
+        <plugin
+            name="after_get_tnw_authorize_cim_vault_active_value"
+            type="TNW\AuthorizeCim\Plugin\Framework\App\Config\AfterGetTnwAuthorizeCimVaultActiveValue"
+        />
+    </type>
+</config>

--- a/view/frontend/web/js/view/payment/method-renderer/authorize.js
+++ b/view/frontend/web/js/view/payment/method-renderer/authorize.js
@@ -162,7 +162,7 @@ function ($, $t, Component, quote, VaultEnabler, validatorManager, validator, fu
          * @returns {Boolean}
          */
         isVaultEnabled: function () {
-            return this.vaultEnabler.isVaultEnabled();
+            return this.vaultEnabler.isVaultEnabled() && window.checkoutConfig.payment[this.getCode()].isCimEnabled;
         },
 
         /**


### PR DESCRIPTION
* Created plugin for app config to override 'active' config value for tnw_authorize_cim_vault when it's falsy and customer have active payment tokens.
* Reworked storefront js to not to display 'Save for later use' flag when CIM is disabled, but vault is actually enabled.